### PR TITLE
feat: create Auth layout, add Login page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ant-design/icons": "^6.0.0",
         "@ant-design/nextjs-registry": "^1.0.2",
+        "@ant-design/v5-patch-for-react-19": "^1.0.3",
         "@hookform/resolvers": "^5.0.1",
         "antd": "^5.25.4",
         "next": "15.3.3",
@@ -131,6 +132,19 @@
       },
       "peerDependencies": {
         "react": ">=16.9.0"
+      }
+    },
+    "node_modules/@ant-design/v5-patch-for-react-19": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@ant-design/v5-patch-for-react-19/-/v5-patch-for-react-19-1.0.3.tgz",
+      "integrity": "sha512-iWfZuSUl5kuhqLUw7jJXUQFMMkM7XpW7apmKzQBQHU0cpifYW4A79xIBt9YVO5IBajKpPG5UKP87Ft7Yrw1p/w==",
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "antd": ">=5.22.6",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@ant-design/icons": "^6.0.0",
     "@ant-design/nextjs-registry": "^1.0.2",
+    "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@hookform/resolvers": "^5.0.1",
     "antd": "^5.25.4",
     "next": "15.3.3",

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Page = () => {
+  return <div>Забули пароль</div>;
+};
+
+export default Page;

--- a/src/app/(auth)/layout.module.scss
+++ b/src/app/(auth)/layout.module.scss
@@ -1,0 +1,12 @@
+.layout:global(.ant-layout) {
+  min-height: 100vh;
+}
+
+.content:global(.ant-flex) {
+  height: 100%;
+  margin: 20px;
+
+  .contentCard {
+    width: 400px;
+  }
+}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,25 @@
+import { Card, Flex, Layout } from 'antd';
+import { Content } from 'antd/es/layout/layout';
+
+import styles from './layout.module.scss';
+
+import { Header, ThemeProvider } from '@/app/components';
+
+const AuthLayout = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <ThemeProvider>
+      <Layout className={styles.layout}>
+        <Header />
+        <Content>
+          <Flex justify="center" align="center" className={styles.content}>
+            <Card className={styles.contentCard} variant="borderless">
+              {children}
+            </Card>
+          </Flex>
+        </Content>
+      </Layout>
+    </ThemeProvider>
+  );
+};
+
+export default AuthLayout;

--- a/src/app/(auth)/login/page.module.scss
+++ b/src/app/(auth)/login/page.module.scss
@@ -1,0 +1,10 @@
+@import "src/shared/ui/styles/utils";
+
+.form {
+  max-width: 400px;
+  width: 100%;
+}
+
+.error {
+  @include input-error-message;
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Flex, Form, Input, Typography } from 'antd';
+import Link from 'next/link';
+import React, { useCallback } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+
+import styles from './page.module.scss';
+
+import { TLoginForm, loginSchema } from '@/features/auth/validation';
+
+const { Password } = Input;
+const { Item } = Form;
+const { Title } = Typography;
+
+const Page = () => {
+  const {
+    handleSubmit,
+    control,
+    formState: { errors, isSubmitting },
+  } = useForm<TLoginForm>({
+    resolver: zodResolver(loginSchema),
+  });
+
+  const onSubmit = (data: TLoginForm) => console.log('Form submitted:', data);
+
+  const renderPasswordExtra = useCallback(
+    () => (
+      <Flex justify="space-between" className={styles.passwordExtra}>
+        <div>
+          {errors.password && errors.password.message && (
+            <span className={styles.error}>{errors.password.message}</span>
+          )}
+        </div>
+        <Link href="/forgot-password">Забули пароль?</Link>
+      </Flex>
+    ),
+    [errors.password],
+  );
+
+  return (
+    <Flex vertical gap={20} align="center">
+      <Title level={2}>Вхід</Title>
+
+      <Form layout="vertical" className={styles.form} onFinish={handleSubmit(onSubmit)}>
+        <Item
+          label="Електронна адреса"
+          extra={errors.email ? <span className={styles.error}>{errors.email.message}</span> : null}
+        >
+          <Controller
+            name="email"
+            control={control}
+            render={({ field }) => (
+              <Input placeholder="example@domain.com" status={errors.email ? 'error' : ''} {...field} />
+            )}
+          />
+        </Item>
+        <Item label="Пароль" extra={renderPasswordExtra()}>
+          <Controller
+            name="password"
+            control={control}
+            render={({ field }) => (
+              <Password status={errors.password ? 'error' : ''} placeholder="********" {...field} />
+            )}
+          />
+        </Item>
+        <Button block type="primary" htmlType="submit" disabled={isSubmitting}>
+          Увійти
+        </Button>
+      </Form>
+    </Flex>
+  );
+};
+
+export default Page;

--- a/src/app/components/Header/Header.tsx
+++ b/src/app/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { MoonOutlined } from '@ant-design/icons';
 import { Button, Flex, Tooltip } from 'antd';
 import { Header as AntHeader } from 'antd/es/layout/layout';

--- a/src/app/components/MainLayout.tsx
+++ b/src/app/components/MainLayout.tsx
@@ -1,32 +1,17 @@
 'use client';
-import { ConfigProvider, Layout } from 'antd';
+import { Layout } from 'antd';
 import { Content } from 'antd/es/layout/layout';
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { DarkTheme, LightTheme } from '@/shared/ui/themes';
-
-import { Header, Sidebar } from '@/app/components';
-
-type ThemeType = 'light' | 'dark';
+import { Header, Sidebar, ThemeProvider } from '@/app/components';
 
 type LayoutProps = {
   children: React.ReactNode;
 };
 
 const MainLayout = ({ children }: LayoutProps) => {
-  const [theme, setTheme] = React.useState<ThemeType>('light');
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const storedTheme = localStorage.getItem('theme') as ThemeType;
-      setTheme(storedTheme);
-    }
-  }, []);
-
-  const themeConfig = theme === 'light' ? DarkTheme : LightTheme;
-
   return (
-    <ConfigProvider theme={themeConfig}>
+    <ThemeProvider>
       <Layout>
         <Header />
 
@@ -35,7 +20,7 @@ const MainLayout = ({ children }: LayoutProps) => {
           <Content>{children}</Content>
         </Layout>
       </Layout>
-    </ConfigProvider>
+    </ThemeProvider>
   );
 };
 

--- a/src/app/components/ThemeProvider.tsx
+++ b/src/app/components/ThemeProvider.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { ConfigProvider } from 'antd';
+import React, { useEffect } from 'react';
+
+import { DarkTheme, LightTheme } from '@/shared/ui/themes';
+
+type ThemeType = 'light' | 'dark';
+
+type IProps = {
+  children: React.ReactNode;
+};
+
+const ThemeProvider = ({ children }: IProps) => {
+  const [theme, setTheme] = React.useState<ThemeType>('light');
+
+  const themeConfig = theme === 'light' ? DarkTheme : LightTheme;
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const storedTheme = localStorage.getItem('theme') as ThemeType;
+      setTheme(storedTheme);
+    }
+  }, []);
+
+  return <ConfigProvider theme={themeConfig}>{children}</ConfigProvider>;
+};
+
+export default ThemeProvider;

--- a/src/app/components/index.ts
+++ b/src/app/components/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header/Header';
 export { default as MainLayout } from './MainLayout';
 export { default as Sidebar } from './Sidebar/Sidebar';
+export { default as ThemeProvider } from './ThemeProvider';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { AntdRegistry } from '@ant-design/nextjs-registry';
+import '@ant-design/v5-patch-for-react-19';
 import type { Metadata } from 'next';
 
 import '@/shared/ui/styles/global.scss';

--- a/src/features/auth/validation.ts
+++ b/src/features/auth/validation.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string({ message: 'Введіть електронну адресу' }).email('Неправильна електронна адреса'),
+  password: z.string({ message: 'Введіть пароль' }).min(1, 'Введіть пароль'),
+});
+
+export type TLoginForm = z.infer<typeof loginSchema>;

--- a/src/shared/ui/styles/global.scss
+++ b/src/shared/ui/styles/global.scss
@@ -1,2 +1,17 @@
 @import 'base';
 @import 'utils';
+
+html, body, #__next {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex-grow: 1;
+}

--- a/src/shared/ui/styles/utils/_index.scss
+++ b/src/shared/ui/styles/utils/_index.scss
@@ -1,2 +1,3 @@
 @import 'variables';
 @import 'functions';
+@import 'mixins';

--- a/src/shared/ui/styles/utils/_mixins.scss
+++ b/src/shared/ui/styles/utils/_mixins.scss
@@ -1,0 +1,5 @@
+@mixin input-error-message {
+  color: var(--ant-color-error);
+  font-size: 0.75rem;
+  margin-top: 0.25rem;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
The scope of current ticket:
- Created a Auth layout for all authorization pages.
- Created a Login page (w/o BE connection yet)
- Integrated Ant.Design input components with RHF+zod
- Created a few reusable items (mixins, folder structure)