### PR TITLE
feat: create offices page and add offices table on company page

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Deploy
 
 inputs:
   DOKPLOY_URL:

--- a/.github/actions/login-to-docker-registry/action.yml
+++ b/.github/actions/login-to-docker-registry/action.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Login to Docker Registry
 
 inputs:
   DOCKER_REGISTRY_URL:

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BankOutlined, MessageOutlined, UserOutlined } from '@ant-design/icons';
+import { ApartmentOutlined, BankOutlined, MessageOutlined, UserOutlined } from '@ant-design/icons';
 import { Link, useLocation } from '@tanstack/react-router';
 import { Menu, type MenuProps } from 'antd';
 import Sider from 'antd/es/layout/Sider';
@@ -44,6 +44,11 @@ const navItems: Record<Role, MenuProps['items']> = {
       label: <Link to="/companies">Організації</Link>,
       icon: <BankOutlined />,
     },
+    {
+      key: '/offices',
+      label: <Link to="/offices">Офіси</Link>,
+      icon: <ApartmentOutlined />,
+    },
   ],
   EDITOR: [
     {
@@ -55,6 +60,11 @@ const navItems: Record<Role, MenuProps['items']> = {
       key: '/companies',
       label: <Link to="/companies">Організації</Link>,
       icon: <BankOutlined />,
+    },
+    {
+      key: '/offices',
+      label: <Link to="/offices">Офіси</Link>,
+      icon: <ApartmentOutlined />,
     },
   ],
 };

--- a/src/components/formatters/FormatDictionaryValue.tsx
+++ b/src/components/formatters/FormatDictionaryValue.tsx
@@ -1,12 +1,25 @@
 import { type DICTIONARY_KEYS, useDictionaryService } from '@services/dictionary-service.tsx';
 
 interface Props {
-  value: number;
+  value: number | number[];
   dictionaryKey: DICTIONARY_KEYS;
 }
 
 const FormatDictionaryValue = ({ value, dictionaryKey }: Props) => {
   const dictionary = useDictionaryService(dictionaryKey, false);
+
+  if (Array.isArray(value)) {
+    const foundItems = dictionary.filter((item) => value.includes(item.id));
+
+    return (
+      <>
+        {foundItems.map((item) => (
+          <div key={item.id}>{item.name || '-'}</div>
+        ))}
+      </>
+    );
+  }
+
   const foundItem = dictionary.find((item) => item.id === value);
 
   return <div>{foundItem?.name || '-'}</div>;

--- a/src/features/company/components/CompanyPage/CompanyPage.tsx
+++ b/src/features/company/components/CompanyPage/CompanyPage.tsx
@@ -30,7 +30,7 @@ const CompanyPage = ({ data }: { data: CompanyDTO }) => {
   const { mutate, isPending } = useMutation({
     mutationKey: ['update-company', data?.id],
     mutationFn: async (body: CompanyInfoSchema | CompanyContactSchema) => {
-      if (!data || !data?.id) return;
+      if (!data?.id) return;
       return await updateCompany(data.id, {
         ...data,
         ...body,
@@ -78,7 +78,7 @@ const CompanyPage = ({ data }: { data: CompanyDTO }) => {
         <Alert
           type="warning"
           showIcon
-          message="Перевірте дані та вкажіть результат перевірки за допомогою кнопки 'Верифікувати'"
+          message={'Перевірте дані та вкажіть результат перевірки за допомогою кнопки "Верифікувати"'}
         />
       )}
       {data.status === 'REJECTED' && (

--- a/src/features/company/components/CompanyTabs/CompanyTabs.tsx
+++ b/src/features/company/components/CompanyTabs/CompanyTabs.tsx
@@ -1,15 +1,43 @@
-import { ApartmentOutlined, UserOutlined } from '@ant-design/icons';
+import { ApartmentOutlined, UnorderedListOutlined, UserOutlined } from '@ant-design/icons';
+import { Outlet, useLocation, useNavigate, useParams } from '@tanstack/react-router';
 import { Tabs } from 'antd';
+import { useMemo } from 'react';
 
-const CompanyTabs = () => {
+enum TabKey {
+  OFFICES = 'offices',
+  USERS = 'users',
+  LOGS = 'logs',
+}
+
+const tabsConfig: Record<TabKey, { label: string; icon: React.ReactElement; to: string }> = {
+  [TabKey.OFFICES]: { label: 'Офіси', icon: <ApartmentOutlined />, to: '/companies/$companyId' },
+  // TODO: Implement users and logs tabs
+  [TabKey.USERS]: { label: 'Користувачі', icon: <UserOutlined />, to: '/companies/$companyId/users' },
+  [TabKey.LOGS]: { label: 'Логи', icon: <UnorderedListOutlined />, to: '/companies/$companyId/logs' },
+};
+
+const CompanyTabs: React.FC = () => {
+  const { companyId } = useParams({
+    from: '/_authorized/_editor/companies/$companyId',
+  });
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const segments = pathname.split('/').filter(Boolean);
+  const last = segments[segments.length - 1] as TabKey;
+  const activeTab = [TabKey.USERS, TabKey.LOGS].includes(last) ? last : TabKey.OFFICES;
+
+  const tabs = useMemo(() => Object.entries(tabsConfig), []);
+
   return (
-    <Tabs
-      items={[
-        { label: 'Офіси', icon: <ApartmentOutlined />, key: 'offices' },
-        { label: 'Користувачі', icon: <UserOutlined />, key: 'users' },
-      ]}
-      defaultActiveKey="offices"
-    />
+    <>
+      <Tabs
+        activeKey={activeTab}
+        onChange={(key: string) => navigate({ to: tabsConfig[key as TabKey].to, replace: true, params: { companyId } })}
+        items={tabs.map(([key, tab]) => ({ key, label: tab.label, icon: tab.icon }))}
+      />
+      <Outlet />
+    </>
   );
 };
 

--- a/src/features/office/api.ts
+++ b/src/features/office/api.ts
@@ -1,0 +1,27 @@
+import apiClient from '@services/api-client.ts';
+
+import type { OfficeDTO } from './types';
+
+export const getOfficeById = async (id: number): Promise<OfficeDTO> => {
+  return await apiClient.get(`/offices/${id}`).then((res) => res.data);
+};
+
+export const getOffices = async (): Promise<OfficeDTO[]> => {
+  return await apiClient.get(`/offices`).then((res) => res.data);
+};
+
+export const getOfficesByCompanyId = async (companyId: number): Promise<OfficeDTO[]> => {
+  return await apiClient.get(`/offices/company/${companyId}`).then((res) => res.data);
+};
+
+export const updateOffice = async (id: number, updatedOffice: OfficeDTO): Promise<OfficeDTO> => {
+  return await apiClient
+    .put(`/offices/${id}`, {
+      ...updatedOffice,
+    })
+    .then((res) => res.data);
+};
+
+export const deleteOffice = async (id: number) => {
+  return await apiClient.delete(`/offices/${id}`).then((res) => res.data);
+};

--- a/src/features/office/columns.tsx
+++ b/src/features/office/columns.tsx
@@ -1,0 +1,85 @@
+import { Link } from '@tanstack/react-router';
+import type { ColumnsType } from 'antd/es/table';
+import React from 'react';
+
+import FormatDictionaryValue from '@components/formatters/FormatDictionaryValue';
+
+import { DICTIONARY_KEYS } from '@services/dictionary-service';
+
+import type { OfficeDTO } from './types';
+
+export const getColumns = (renderActions: (row: OfficeDTO) => React.ReactElement): ColumnsType<OfficeDTO> => [
+  {
+    title: 'ID',
+    dataIndex: 'id',
+    sorter: (a, b) => a.id - b.id,
+    showSorterTooltip: {
+      title: 'Сортувати за ID',
+    },
+  },
+  {
+    key: 'locationName',
+    title: 'Адреса',
+    dataIndex: 'locationName',
+    sorter: (a, b) => a.locationName.localeCompare(b.locationName),
+    showSorterTooltip: {
+      title: 'Сортувати за адресою',
+    },
+    render: (value: string) => <span style={{ display: 'flex', width: 200 }}>{value || '-'}</span>,
+  },
+  {
+    key: 'additionalDescription',
+    title: 'Опис',
+    dataIndex: 'additionalDescription',
+    sorter: false,
+    render: (value: string) => <span style={{ display: 'flex', width: 200 }}>{value || '-'}</span>,
+  },
+  {
+    key: 'workSchedule',
+    title: 'Графік роботи',
+    dataIndex: 'workSchedule',
+    sorter: false,
+    render: (value: string) => <span style={{ display: 'flex', width: 200 }}>{value || '-'}</span>,
+  },
+  {
+    key: 'companyId',
+    title: 'Компанія',
+    dataIndex: 'companyId',
+    sorter: (a, b) => a.companyId - b.companyId,
+    showSorterTooltip: {
+      title: 'Сортувати за компанією',
+    },
+    render: (value) => (
+      <Link to="/companies/$companyId" params={{ companyId: value }}>
+        {value}
+      </Link>
+    ),
+  },
+  {
+    key: 'categoryIds',
+    title: 'Категорії',
+    dataIndex: 'categoryIds',
+    sorter: false,
+    render: (value) => <FormatDictionaryValue value={value} dictionaryKey={DICTIONARY_KEYS.categories} />,
+  },
+  {
+    key: 'conditionIds',
+    title: 'Умови',
+    dataIndex: 'conditionIds',
+    sorter: false,
+    render: (value) => <FormatDictionaryValue value={value} dictionaryKey={DICTIONARY_KEYS.conditions} />,
+  },
+  {
+    key: 'serviceIds',
+    title: 'Послуги',
+    dataIndex: 'serviceIds',
+    sorter: false,
+    render: (value) => <FormatDictionaryValue value={value} dictionaryKey={DICTIONARY_KEYS.services} />,
+  },
+  {
+    key: 'actions',
+    title: 'Дії',
+    render: (_value, row: OfficeDTO) => renderActions(row),
+    fixed: 'right',
+  },
+];

--- a/src/features/office/components/DeleteOfficeAction.tsx
+++ b/src/features/office/components/DeleteOfficeAction.tsx
@@ -1,0 +1,70 @@
+import { DeleteOutlined } from '@ant-design/icons';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button, Tooltip } from 'antd';
+import { useCallback } from 'react';
+
+import { deleteOffice } from '@features/office/api.ts';
+
+import { useAlertContext } from '@shared/providers/AlertProvider.tsx';
+
+import type { OfficeDTO } from '../types';
+
+const DeleteOfficeAction = ({ showText, office }: { showText?: boolean; office: OfficeDTO }) => {
+  const alertContext = useAlertContext();
+  const queryClient = useQueryClient();
+
+  const { mutate: deleteMutation } = useMutation({
+    mutationKey: ['delete-office', office.id],
+    mutationFn: async () => {
+      await deleteOffice(office.id);
+      return true;
+    },
+    onSuccess: async () => {
+      if (alertContext) {
+        alertContext.openNotification('Офіс успішно видалено', 'success');
+        await queryClient.refetchQueries({ queryKey: ['companies'], type: 'all' });
+      }
+    },
+    onError: () => {
+      if (alertContext) {
+        alertContext.openNotification('Не вдалося видалити організацію. Спробуйте ще раз', 'error');
+      }
+    },
+  });
+
+  const onDelete = useCallback(() => {
+    if (alertContext) {
+      alertContext.openDialog({
+        title: (
+          <p>
+            Ви дійсно бажаєте видалити офіс за адресою <strong>{office.locationName}</strong>?
+          </p>
+        ),
+        kind: 'danger',
+        message: "Всі дані пов'язані з цим офісом, будуть видалені без можливості відновлення.",
+        confirm: 'Видалити',
+        cancel: 'Скасувати',
+        resolve: deleteMutation,
+        reject: () => {},
+      });
+    }
+  }, [alertContext, office.locationName, deleteMutation]);
+
+  return (
+    <Tooltip title="Видалити офіс">
+      <Button
+        variant="outlined"
+        color="danger"
+        icon={<DeleteOutlined />}
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+      >
+        {showText && 'Видалити'}
+      </Button>
+    </Tooltip>
+  );
+};
+
+export default DeleteOfficeAction;

--- a/src/features/office/components/OfficesTable/OfficesTable.module.scss
+++ b/src/features/office/components/OfficesTable/OfficesTable.module.scss
@@ -1,0 +1,3 @@
+.row:hover {
+  cursor: pointer;
+}

--- a/src/features/office/components/OfficesTable/OfficesTable.tsx
+++ b/src/features/office/components/OfficesTable/OfficesTable.tsx
@@ -1,0 +1,100 @@
+import { EyeOutlined } from '@ant-design/icons';
+import { useNavigate } from '@tanstack/react-router';
+import { Button, Card, Flex, Input, Table, Tooltip, Typography } from 'antd';
+import type { SorterResult } from 'antd/es/table/interface';
+import { useCallback, useMemo } from 'react';
+
+import { getColumns } from '@features/office/columns';
+
+import filterTableData from '@services/filter-table-data.ts';
+import mapColumnsWithSort from '@services/sort-columns.ts';
+
+import useTableState from '@shared/hooks/useTableState.ts';
+
+import DeleteOfficeAction from '../DeleteOfficeAction';
+
+import styles from './OfficesTable.module.scss';
+
+import type { OfficeDTO } from '../../types';
+
+import { Permission } from '@/features/session/types';
+import type { FileRouteTypes } from '@/routeTree.gen';
+import { currentUserHasPermissions } from '@/services/has-permissions';
+
+type OfficesTableProps = {
+  data: OfficeDTO[];
+  route: FileRouteTypes['id'];
+  isCompanyOffice?: boolean;
+};
+
+const OfficesTable: React.FC<OfficesTableProps> = ({ data, route, isCompanyOffice }) => {
+  const navigate = useNavigate();
+  const { changePage, page, pageSize, changeSearch, search, changeSorting, sortBy, sortAsc } = useTableState(route);
+
+  const { pageFilteredData, total } = useMemo(
+    () => filterTableData(data || [], page, pageSize, search, ['locationName', 'companyId']),
+    [data, page, pageSize, search],
+  );
+
+  const renderActions = useCallback(
+    (row: OfficeDTO) => {
+      return (
+        <Flex gap={4}>
+          <Tooltip title="Переглянути офіс">
+            <Button variant="outlined" icon={<EyeOutlined />} onClick={() => navigate({ to: `/offices/${row.id}` })} />
+          </Tooltip>
+
+          {currentUserHasPermissions(isCompanyOffice ? Permission.COMPANY_OFFICE_DELETE : Permission.OFFICE_DELETE) && (
+            <DeleteOfficeAction office={row} />
+          )}
+        </Flex>
+      );
+    },
+    [isCompanyOffice, navigate],
+  );
+
+  const columns = useMemo(() => getColumns(renderActions), [renderActions]);
+
+  return (
+    <Card
+      title={
+        <Flex align="center" gap={20}>
+          {!isCompanyOffice && (
+            <Typography.Title level={3} style={{ marginBottom: 0 }}>
+              Офіси
+            </Typography.Title>
+          )}
+          <Button>Створити офіс</Button>
+        </Flex>
+      }
+      style={{ margin: !isCompanyOffice ? 20 : 0 }}
+      styles={{ body: { padding: 0 } }}
+      extra={<Input.Search allowClear defaultValue={search} placeholder="Пошук" onSearch={changeSearch} />}
+    >
+      <Table
+        className="ant-responsive-table"
+        rowClassName={styles.row}
+        dataSource={pageFilteredData}
+        columns={mapColumnsWithSort<OfficeDTO>(columns, sortBy, sortAsc)}
+        onChange={(_pagination, _filters, sorter, { action }) => {
+          changeSorting(action, sorter as SorterResult<unknown>);
+        }}
+        locale={{
+          emptyText: 'Немає офісів для відображення',
+        }}
+        onRow={(record) => ({
+          onClick: () => navigate({ to: `/offices/${record.id}` }),
+        })}
+        pagination={{
+          total: total || 0,
+          showTotal: (totalCount: number) => `Всього: ${totalCount}`,
+          current: page,
+          pageSize: pageSize,
+          onChange: changePage,
+        }}
+      />
+    </Card>
+  );
+};
+
+export default OfficesTable;

--- a/src/features/office/queries.ts
+++ b/src/features/office/queries.ts
@@ -1,0 +1,24 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { getOfficeById, getOffices, getOfficesByCompanyId } from '@features/office/api.ts';
+
+export const createOfficeByIdQueryOptions = (officeId: number) => {
+  return queryOptions({
+    queryKey: ['office', officeId],
+    queryFn: () => getOfficeById(officeId),
+  });
+};
+
+export const createOfficesQueryOptions = () => {
+  return queryOptions({
+    queryKey: ['offices'],
+    queryFn: () => getOffices(),
+  });
+};
+
+export const createOfficeByCompanyIdQueryOptions = (companyId: number) => {
+  return queryOptions({
+    queryKey: ['company/offices', companyId],
+    queryFn: () => getOfficesByCompanyId(companyId),
+  });
+};

--- a/src/features/office/types.ts
+++ b/src/features/office/types.ts
@@ -1,0 +1,14 @@
+export interface OfficeDTO {
+  id: number;
+  workSchedule: string;
+  donorSupport?: string;
+  additionalDescription?: string;
+  locationName: string;
+  latitude: number;
+  longitude: number;
+  regionId: number;
+  companyId: number;
+  serviceIds: number[];
+  categoryIds: number[];
+  conditionIds: number[];
+}

--- a/src/features/session/store.ts
+++ b/src/features/session/store.ts
@@ -8,7 +8,7 @@ type SessionStore = {
   setData: (data: SessionInfo | null) => void;
 };
 
-const useSessionStore = create<SessionStore>()(
+export const useSessionStore = create<SessionStore>()(
   persist(
     (set) => ({
       data: null,

--- a/src/features/session/types.ts
+++ b/src/features/session/types.ts
@@ -9,18 +9,18 @@ export type SessionInfo = {
 
 export enum Role {
   ADMIN = 'ADMIN',
-  COMPANY_USER = 'COMPANY_USER',
   COMPANY_ADMIN = 'COMPANY_ADMIN',
+  COMPANY_USER = 'COMPANY_USER',
   EDITOR = 'EDITOR',
 }
 
 export enum Permission {
-  // Chats
+  // Chat
   CHAT_VIEW = 'chat:view',
   CHAT_CREATE = 'chat:create',
   CHAT_DELETE = 'chat:delete',
   CHAT_SEND_MESSAGE = 'chat:send_message',
-  // Users
+  // User
   USERS_VIEW = 'users:view',
   USER_VIEW = 'user:view',
   USER_INVITE = 'user:invite',
@@ -28,13 +28,19 @@ export enum Permission {
   USER_UPDATE = 'user:update',
   USER_DELETE = 'user:delete',
   USER_RESET_PASSWORD = 'user:reset_password',
-  // Companies
+  // Company
   COMPANIES_VIEW = 'companies:view',
   COMPANY_VIEW = 'company:view',
   COMPANY_CREATE = 'company:create',
   COMPANY_UPDATE = 'company:update',
   COMPANY_DELETE = 'company:delete',
-  // Offices
+  // Company Office
+  COMPANY_OFFICES_VIEW = 'company-offices:view',
+  COMPANY_OFFICE_VIEW = 'company-office:view',
+  COMPANY_OFFICE_CREATE = 'company-office:create',
+  COMPANY_OFFICE_UPDATE = 'company-office:update',
+  COMPANY_OFFICE_DELETE = 'company-office:delete',
+  // Office
   OFFICES_VIEW = 'offices:view',
   OFFICE_VIEW = 'office:view',
   OFFICE_CREATE = 'office:create',

--- a/src/features/session/types.ts
+++ b/src/features/session/types.ts
@@ -13,3 +13,31 @@ export enum Role {
   COMPANY_ADMIN = 'COMPANY_ADMIN',
   EDITOR = 'EDITOR',
 }
+
+export enum Permission {
+  // Chats
+  CHAT_VIEW = 'chat:view',
+  CHAT_CREATE = 'chat:create',
+  CHAT_DELETE = 'chat:delete',
+  CHAT_SEND_MESSAGE = 'chat:send_message',
+  // Users
+  USERS_VIEW = 'users:view',
+  USER_VIEW = 'user:view',
+  USER_INVITE = 'user:invite',
+  USER_CREATE = 'user:create',
+  USER_UPDATE = 'user:update',
+  USER_DELETE = 'user:delete',
+  USER_RESET_PASSWORD = 'user:reset_password',
+  // Companies
+  COMPANIES_VIEW = 'companies:view',
+  COMPANY_VIEW = 'company:view',
+  COMPANY_CREATE = 'company:create',
+  COMPANY_UPDATE = 'company:update',
+  COMPANY_DELETE = 'company:delete',
+  // Offices
+  OFFICES_VIEW = 'offices:view',
+  OFFICE_VIEW = 'office:view',
+  OFFICE_CREATE = 'office:create',
+  OFFICE_UPDATE = 'office:update',
+  OFFICE_DELETE = 'office:delete',
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,9 +24,15 @@ import { Route as UnauthorizedSignUpTokenRouteImport } from './routes/_unauthori
 import { Route as UnauthorizedResetPasswordTokenRouteImport } from './routes/_unauthorized/reset-password.$token'
 import { Route as AuthorizedEditorUsersRouteImport } from './routes/_authorized/_editor/users'
 import { Route as AuthorizedCompanyAdminCompanyRouteImport } from './routes/_authorized/_companyAdmin/company'
+import { Route as AuthorizedEditorOfficesRouteRouteImport } from './routes/_authorized/_editor/offices/route'
 import { Route as AuthorizedEditorCompaniesRouteRouteImport } from './routes/_authorized/_editor/companies/route'
+import { Route as AuthorizedEditorOfficesIndexRouteImport } from './routes/_authorized/_editor/offices/index'
 import { Route as AuthorizedEditorCompaniesIndexRouteImport } from './routes/_authorized/_editor/companies/index'
+import { Route as AuthorizedEditorOfficesOfficeIdRouteRouteImport } from './routes/_authorized/_editor/offices/$officeId/route'
 import { Route as AuthorizedEditorCompaniesCompanyIdRouteRouteImport } from './routes/_authorized/_editor/companies/$companyId/route'
+import { Route as AuthorizedEditorCompaniesCompanyIdIndexRouteImport } from './routes/_authorized/_editor/companies/$companyId/index'
+import { Route as AuthorizedEditorCompaniesCompanyIdUsersRouteImport } from './routes/_authorized/_editor/companies/$companyId/users'
+import { Route as AuthorizedEditorCompaniesCompanyIdLogsRouteImport } from './routes/_authorized/_editor/companies/$companyId/logs'
 
 const UnauthorizedRouteRoute = UnauthorizedRouteRouteImport.update({
   id: '/_unauthorized',
@@ -102,11 +108,23 @@ const AuthorizedCompanyAdminCompanyRoute =
     path: '/company',
     getParentRoute: () => AuthorizedCompanyAdminRouteRoute,
   } as any)
+const AuthorizedEditorOfficesRouteRoute =
+  AuthorizedEditorOfficesRouteRouteImport.update({
+    id: '/offices',
+    path: '/offices',
+    getParentRoute: () => AuthorizedEditorRouteRoute,
+  } as any)
 const AuthorizedEditorCompaniesRouteRoute =
   AuthorizedEditorCompaniesRouteRouteImport.update({
     id: '/companies',
     path: '/companies',
     getParentRoute: () => AuthorizedEditorRouteRoute,
+  } as any)
+const AuthorizedEditorOfficesIndexRoute =
+  AuthorizedEditorOfficesIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthorizedEditorOfficesRouteRoute,
   } as any)
 const AuthorizedEditorCompaniesIndexRoute =
   AuthorizedEditorCompaniesIndexRouteImport.update({
@@ -114,11 +132,35 @@ const AuthorizedEditorCompaniesIndexRoute =
     path: '/',
     getParentRoute: () => AuthorizedEditorCompaniesRouteRoute,
   } as any)
+const AuthorizedEditorOfficesOfficeIdRouteRoute =
+  AuthorizedEditorOfficesOfficeIdRouteRouteImport.update({
+    id: '/$officeId',
+    path: '/$officeId',
+    getParentRoute: () => AuthorizedEditorOfficesRouteRoute,
+  } as any)
 const AuthorizedEditorCompaniesCompanyIdRouteRoute =
   AuthorizedEditorCompaniesCompanyIdRouteRouteImport.update({
     id: '/$companyId',
     path: '/$companyId',
     getParentRoute: () => AuthorizedEditorCompaniesRouteRoute,
+  } as any)
+const AuthorizedEditorCompaniesCompanyIdIndexRoute =
+  AuthorizedEditorCompaniesCompanyIdIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthorizedEditorCompaniesCompanyIdRouteRoute,
+  } as any)
+const AuthorizedEditorCompaniesCompanyIdUsersRoute =
+  AuthorizedEditorCompaniesCompanyIdUsersRouteImport.update({
+    id: '/users',
+    path: '/users',
+    getParentRoute: () => AuthorizedEditorCompaniesCompanyIdRouteRoute,
+  } as any)
+const AuthorizedEditorCompaniesCompanyIdLogsRoute =
+  AuthorizedEditorCompaniesCompanyIdLogsRouteImport.update({
+    id: '/logs',
+    path: '/logs',
+    getParentRoute: () => AuthorizedEditorCompaniesCompanyIdRouteRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -129,12 +171,18 @@ export interface FileRoutesByFullPath {
   '/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/login': typeof UnauthorizedLoginRoute
   '/companies': typeof AuthorizedEditorCompaniesRouteRouteWithChildren
+  '/offices': typeof AuthorizedEditorOfficesRouteRouteWithChildren
   '/company': typeof AuthorizedCompanyAdminCompanyRoute
   '/users': typeof AuthorizedEditorUsersRoute
   '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
   '/sign-up/$token': typeof UnauthorizedSignUpTokenRoute
-  '/companies/$companyId': typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
+  '/companies/$companyId': typeof AuthorizedEditorCompaniesCompanyIdRouteRouteWithChildren
+  '/offices/$officeId': typeof AuthorizedEditorOfficesOfficeIdRouteRoute
   '/companies/': typeof AuthorizedEditorCompaniesIndexRoute
+  '/offices/': typeof AuthorizedEditorOfficesIndexRoute
+  '/companies/$companyId/logs': typeof AuthorizedEditorCompaniesCompanyIdLogsRoute
+  '/companies/$companyId/users': typeof AuthorizedEditorCompaniesCompanyIdUsersRoute
+  '/companies/$companyId/': typeof AuthorizedEditorCompaniesCompanyIdIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -147,8 +195,12 @@ export interface FileRoutesByTo {
   '/users': typeof AuthorizedEditorUsersRoute
   '/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
   '/sign-up/$token': typeof UnauthorizedSignUpTokenRoute
-  '/companies/$companyId': typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
+  '/offices/$officeId': typeof AuthorizedEditorOfficesOfficeIdRouteRoute
   '/companies': typeof AuthorizedEditorCompaniesIndexRoute
+  '/offices': typeof AuthorizedEditorOfficesIndexRoute
+  '/companies/$companyId/logs': typeof AuthorizedEditorCompaniesCompanyIdLogsRoute
+  '/companies/$companyId/users': typeof AuthorizedEditorCompaniesCompanyIdUsersRoute
+  '/companies/$companyId': typeof AuthorizedEditorCompaniesCompanyIdIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -164,12 +216,18 @@ export interface FileRoutesById {
   '/_unauthorized/forgot-password': typeof UnauthorizedForgotPasswordRoute
   '/_unauthorized/login': typeof UnauthorizedLoginRoute
   '/_authorized/_editor/companies': typeof AuthorizedEditorCompaniesRouteRouteWithChildren
+  '/_authorized/_editor/offices': typeof AuthorizedEditorOfficesRouteRouteWithChildren
   '/_authorized/_companyAdmin/company': typeof AuthorizedCompanyAdminCompanyRoute
   '/_authorized/_editor/users': typeof AuthorizedEditorUsersRoute
   '/_unauthorized/reset-password/$token': typeof UnauthorizedResetPasswordTokenRoute
   '/_unauthorized/sign-up/$token': typeof UnauthorizedSignUpTokenRoute
-  '/_authorized/_editor/companies/$companyId': typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
+  '/_authorized/_editor/companies/$companyId': typeof AuthorizedEditorCompaniesCompanyIdRouteRouteWithChildren
+  '/_authorized/_editor/offices/$officeId': typeof AuthorizedEditorOfficesOfficeIdRouteRoute
   '/_authorized/_editor/companies/': typeof AuthorizedEditorCompaniesIndexRoute
+  '/_authorized/_editor/offices/': typeof AuthorizedEditorOfficesIndexRoute
+  '/_authorized/_editor/companies/$companyId/logs': typeof AuthorizedEditorCompaniesCompanyIdLogsRoute
+  '/_authorized/_editor/companies/$companyId/users': typeof AuthorizedEditorCompaniesCompanyIdUsersRoute
+  '/_authorized/_editor/companies/$companyId/': typeof AuthorizedEditorCompaniesCompanyIdIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -181,12 +239,18 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/login'
     | '/companies'
+    | '/offices'
     | '/company'
     | '/users'
     | '/reset-password/$token'
     | '/sign-up/$token'
     | '/companies/$companyId'
+    | '/offices/$officeId'
     | '/companies/'
+    | '/offices/'
+    | '/companies/$companyId/logs'
+    | '/companies/$companyId/users'
+    | '/companies/$companyId/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -199,8 +263,12 @@ export interface FileRouteTypes {
     | '/users'
     | '/reset-password/$token'
     | '/sign-up/$token'
-    | '/companies/$companyId'
+    | '/offices/$officeId'
     | '/companies'
+    | '/offices'
+    | '/companies/$companyId/logs'
+    | '/companies/$companyId/users'
+    | '/companies/$companyId'
   id:
     | '__root__'
     | '/'
@@ -215,12 +283,18 @@ export interface FileRouteTypes {
     | '/_unauthorized/forgot-password'
     | '/_unauthorized/login'
     | '/_authorized/_editor/companies'
+    | '/_authorized/_editor/offices'
     | '/_authorized/_companyAdmin/company'
     | '/_authorized/_editor/users'
     | '/_unauthorized/reset-password/$token'
     | '/_unauthorized/sign-up/$token'
     | '/_authorized/_editor/companies/$companyId'
+    | '/_authorized/_editor/offices/$officeId'
     | '/_authorized/_editor/companies/'
+    | '/_authorized/_editor/offices/'
+    | '/_authorized/_editor/companies/$companyId/logs'
+    | '/_authorized/_editor/companies/$companyId/users'
+    | '/_authorized/_editor/companies/$companyId/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -336,12 +410,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedCompanyAdminCompanyRouteImport
       parentRoute: typeof AuthorizedCompanyAdminRouteRoute
     }
+    '/_authorized/_editor/offices': {
+      id: '/_authorized/_editor/offices'
+      path: '/offices'
+      fullPath: '/offices'
+      preLoaderRoute: typeof AuthorizedEditorOfficesRouteRouteImport
+      parentRoute: typeof AuthorizedEditorRouteRoute
+    }
     '/_authorized/_editor/companies': {
       id: '/_authorized/_editor/companies'
       path: '/companies'
       fullPath: '/companies'
       preLoaderRoute: typeof AuthorizedEditorCompaniesRouteRouteImport
       parentRoute: typeof AuthorizedEditorRouteRoute
+    }
+    '/_authorized/_editor/offices/': {
+      id: '/_authorized/_editor/offices/'
+      path: '/'
+      fullPath: '/offices/'
+      preLoaderRoute: typeof AuthorizedEditorOfficesIndexRouteImport
+      parentRoute: typeof AuthorizedEditorOfficesRouteRoute
     }
     '/_authorized/_editor/companies/': {
       id: '/_authorized/_editor/companies/'
@@ -350,12 +438,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthorizedEditorCompaniesIndexRouteImport
       parentRoute: typeof AuthorizedEditorCompaniesRouteRoute
     }
+    '/_authorized/_editor/offices/$officeId': {
+      id: '/_authorized/_editor/offices/$officeId'
+      path: '/$officeId'
+      fullPath: '/offices/$officeId'
+      preLoaderRoute: typeof AuthorizedEditorOfficesOfficeIdRouteRouteImport
+      parentRoute: typeof AuthorizedEditorOfficesRouteRoute
+    }
     '/_authorized/_editor/companies/$companyId': {
       id: '/_authorized/_editor/companies/$companyId'
       path: '/$companyId'
       fullPath: '/companies/$companyId'
       preLoaderRoute: typeof AuthorizedEditorCompaniesCompanyIdRouteRouteImport
       parentRoute: typeof AuthorizedEditorCompaniesRouteRoute
+    }
+    '/_authorized/_editor/companies/$companyId/': {
+      id: '/_authorized/_editor/companies/$companyId/'
+      path: '/'
+      fullPath: '/companies/$companyId/'
+      preLoaderRoute: typeof AuthorizedEditorCompaniesCompanyIdIndexRouteImport
+      parentRoute: typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
+    }
+    '/_authorized/_editor/companies/$companyId/users': {
+      id: '/_authorized/_editor/companies/$companyId/users'
+      path: '/users'
+      fullPath: '/companies/$companyId/users'
+      preLoaderRoute: typeof AuthorizedEditorCompaniesCompanyIdUsersRouteImport
+      parentRoute: typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
+    }
+    '/_authorized/_editor/companies/$companyId/logs': {
+      id: '/_authorized/_editor/companies/$companyId/logs'
+      path: '/logs'
+      fullPath: '/companies/$companyId/logs'
+      preLoaderRoute: typeof AuthorizedEditorCompaniesCompanyIdLogsRouteImport
+      parentRoute: typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
     }
   }
 }
@@ -374,15 +490,36 @@ const AuthorizedCompanyAdminRouteRouteWithChildren =
     AuthorizedCompanyAdminRouteRouteChildren,
   )
 
+interface AuthorizedEditorCompaniesCompanyIdRouteRouteChildren {
+  AuthorizedEditorCompaniesCompanyIdLogsRoute: typeof AuthorizedEditorCompaniesCompanyIdLogsRoute
+  AuthorizedEditorCompaniesCompanyIdUsersRoute: typeof AuthorizedEditorCompaniesCompanyIdUsersRoute
+  AuthorizedEditorCompaniesCompanyIdIndexRoute: typeof AuthorizedEditorCompaniesCompanyIdIndexRoute
+}
+
+const AuthorizedEditorCompaniesCompanyIdRouteRouteChildren: AuthorizedEditorCompaniesCompanyIdRouteRouteChildren =
+  {
+    AuthorizedEditorCompaniesCompanyIdLogsRoute:
+      AuthorizedEditorCompaniesCompanyIdLogsRoute,
+    AuthorizedEditorCompaniesCompanyIdUsersRoute:
+      AuthorizedEditorCompaniesCompanyIdUsersRoute,
+    AuthorizedEditorCompaniesCompanyIdIndexRoute:
+      AuthorizedEditorCompaniesCompanyIdIndexRoute,
+  }
+
+const AuthorizedEditorCompaniesCompanyIdRouteRouteWithChildren =
+  AuthorizedEditorCompaniesCompanyIdRouteRoute._addFileChildren(
+    AuthorizedEditorCompaniesCompanyIdRouteRouteChildren,
+  )
+
 interface AuthorizedEditorCompaniesRouteRouteChildren {
-  AuthorizedEditorCompaniesCompanyIdRouteRoute: typeof AuthorizedEditorCompaniesCompanyIdRouteRoute
+  AuthorizedEditorCompaniesCompanyIdRouteRoute: typeof AuthorizedEditorCompaniesCompanyIdRouteRouteWithChildren
   AuthorizedEditorCompaniesIndexRoute: typeof AuthorizedEditorCompaniesIndexRoute
 }
 
 const AuthorizedEditorCompaniesRouteRouteChildren: AuthorizedEditorCompaniesRouteRouteChildren =
   {
     AuthorizedEditorCompaniesCompanyIdRouteRoute:
-      AuthorizedEditorCompaniesCompanyIdRouteRoute,
+      AuthorizedEditorCompaniesCompanyIdRouteRouteWithChildren,
     AuthorizedEditorCompaniesIndexRoute: AuthorizedEditorCompaniesIndexRoute,
   }
 
@@ -391,14 +528,34 @@ const AuthorizedEditorCompaniesRouteRouteWithChildren =
     AuthorizedEditorCompaniesRouteRouteChildren,
   )
 
+interface AuthorizedEditorOfficesRouteRouteChildren {
+  AuthorizedEditorOfficesOfficeIdRouteRoute: typeof AuthorizedEditorOfficesOfficeIdRouteRoute
+  AuthorizedEditorOfficesIndexRoute: typeof AuthorizedEditorOfficesIndexRoute
+}
+
+const AuthorizedEditorOfficesRouteRouteChildren: AuthorizedEditorOfficesRouteRouteChildren =
+  {
+    AuthorizedEditorOfficesOfficeIdRouteRoute:
+      AuthorizedEditorOfficesOfficeIdRouteRoute,
+    AuthorizedEditorOfficesIndexRoute: AuthorizedEditorOfficesIndexRoute,
+  }
+
+const AuthorizedEditorOfficesRouteRouteWithChildren =
+  AuthorizedEditorOfficesRouteRoute._addFileChildren(
+    AuthorizedEditorOfficesRouteRouteChildren,
+  )
+
 interface AuthorizedEditorRouteRouteChildren {
   AuthorizedEditorCompaniesRouteRoute: typeof AuthorizedEditorCompaniesRouteRouteWithChildren
+  AuthorizedEditorOfficesRouteRoute: typeof AuthorizedEditorOfficesRouteRouteWithChildren
   AuthorizedEditorUsersRoute: typeof AuthorizedEditorUsersRoute
 }
 
 const AuthorizedEditorRouteRouteChildren: AuthorizedEditorRouteRouteChildren = {
   AuthorizedEditorCompaniesRouteRoute:
     AuthorizedEditorCompaniesRouteRouteWithChildren,
+  AuthorizedEditorOfficesRouteRoute:
+    AuthorizedEditorOfficesRouteRouteWithChildren,
   AuthorizedEditorUsersRoute: AuthorizedEditorUsersRoute,
 }
 

--- a/src/routes/_authorized/_editor/companies/$companyId/index.tsx
+++ b/src/routes/_authorized/_editor/companies/$companyId/index.tsx
@@ -1,0 +1,38 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { fallback, zodValidator } from '@tanstack/zod-adapter';
+import z from 'zod';
+
+import OfficesTable from '@features/office/components/OfficesTable/OfficesTable';
+import { createOfficeByCompanyIdQueryOptions } from '@features/office/queries';
+
+const searchSchema = z.object({
+  page: fallback(z.number(), 1).default(1),
+  pageSize: fallback(z.number(), 10).default(10),
+  search: fallback(z.string(), '').default(''),
+  sortBy: fallback(z.enum(['id', 'locationName', 'workSchedule', 'companyId']), 'id').default('id'),
+  sortAsc: fallback(z.boolean(), true).default(true),
+});
+
+export const Route = createFileRoute('/_authorized/_editor/companies/$companyId/')({
+  component: RouteComponent,
+  validateSearch: zodValidator(searchSchema),
+  beforeLoad: async ({ params, context }) => {
+    const { companyId } = params;
+    if (!companyId) {
+      throw redirect({ to: '/companies' });
+    }
+
+    return context.queryClient.ensureQueryData(createOfficeByCompanyIdQueryOptions(+companyId));
+  },
+  onError: () => {
+    throw redirect({ to: '/companies' });
+  },
+});
+
+function RouteComponent() {
+  const { companyId } = Route.useParams();
+  const { data } = useSuspenseQuery(createOfficeByCompanyIdQueryOptions(+companyId));
+
+  return <OfficesTable data={data} route="/_authorized/_editor/companies/$companyId/" isCompanyOffice />;
+}

--- a/src/routes/_authorized/_editor/companies/$companyId/logs.tsx
+++ b/src/routes/_authorized/_editor/companies/$companyId/logs.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authorized/_editor/companies/$companyId/logs')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <div>Логисісі</div>;
+}

--- a/src/routes/_authorized/_editor/companies/$companyId/users.tsx
+++ b/src/routes/_authorized/_editor/companies/$companyId/users.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authorized/_editor/companies/$companyId/users')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <div>Юзерсісі</div>;
+}

--- a/src/routes/_authorized/_editor/offices/$officeId/route.tsx
+++ b/src/routes/_authorized/_editor/offices/$officeId/route.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+import { createOfficeByIdQueryOptions } from '@/features/office/queries';
+
+export const Route = createFileRoute('/_authorized/_editor/offices/$officeId')({
+  component: RouteComponent,
+  beforeLoad: async ({ params, context }) => {
+    const { officeId } = params;
+    if (!officeId) {
+      throw redirect({ to: '/offices' });
+    }
+
+    return context.queryClient.ensureQueryData(createOfficeByIdQueryOptions(+officeId));
+  },
+  onError: () => {
+    throw redirect({ to: '/offices' });
+  },
+});
+
+function RouteComponent() {
+  // TODO: Implement office page
+  // const { officeId } = Route.useParams();
+  // const { data } = useSuspenseQuery(createOfficeByIdQueryOptions(+officeId));
+
+  return <>Офісісі</>;
+}

--- a/src/routes/_authorized/_editor/offices/index.tsx
+++ b/src/routes/_authorized/_editor/offices/index.tsx
@@ -1,0 +1,33 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { fallback, zodValidator } from '@tanstack/zod-adapter';
+import { z } from 'zod';
+
+import OfficesTable from '@features/office/components/OfficesTable/OfficesTable.tsx';
+
+import { createOfficesQueryOptions } from '@/features/office/queries';
+
+const searchSchema = z.object({
+  page: fallback(z.number(), 1).default(1),
+  pageSize: fallback(z.number(), 10).default(10),
+  search: fallback(z.string(), '').default(''),
+  sortBy: fallback(z.enum(['id', 'locationName', 'workSchedule', 'companyId']), 'id').default('id'),
+  sortAsc: fallback(z.boolean(), true).default(true),
+});
+
+export const Route = createFileRoute('/_authorized/_editor/offices/')({
+  component: RouteComponent,
+  validateSearch: zodValidator(searchSchema),
+  beforeLoad: async ({ context }) => {
+    return context.queryClient.ensureQueryData(createOfficesQueryOptions());
+  },
+  onError: () => {
+    throw redirect({ to: '/offices' });
+  },
+});
+
+function RouteComponent() {
+  const { data } = useSuspenseQuery(createOfficesQueryOptions());
+
+  return <OfficesTable data={data} route="/_authorized/_editor/offices/" />;
+}

--- a/src/routes/_authorized/_editor/offices/route.tsx
+++ b/src/routes/_authorized/_editor/offices/route.tsx
@@ -1,0 +1,9 @@
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_authorized/_editor/offices')({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  return <Outlet />;
+}

--- a/src/services/dictionary-service.tsx
+++ b/src/services/dictionary-service.tsx
@@ -8,7 +8,10 @@ export interface DictionaryDTO {
 }
 
 export enum DICTIONARY_KEYS {
+  services = 'services',
+  conditions = 'conditions',
   companyTypes = 'company-types',
+  categories = 'categories',
 }
 
 const getDictionaryQueryOptions = (key: DICTIONARY_KEYS) => ({

--- a/src/services/has-permissions.ts
+++ b/src/services/has-permissions.ts
@@ -1,6 +1,7 @@
+import { useSessionStore } from '@/features/session/store';
 import { Permission, Role } from '@/features/session/types';
 
-const rolesPermissions: Record<Role, Permission[]> = {
+const rolePermissions: Record<Role, Permission[]> = {
   [Role.ADMIN]: [
     Permission.CHAT_VIEW,
     Permission.CHAT_CREATE,
@@ -18,6 +19,11 @@ const rolesPermissions: Record<Role, Permission[]> = {
     Permission.COMPANY_CREATE,
     Permission.COMPANY_UPDATE,
     Permission.COMPANY_DELETE,
+    Permission.COMPANY_OFFICES_VIEW,
+    Permission.COMPANY_OFFICE_VIEW,
+    Permission.COMPANY_OFFICE_CREATE,
+    Permission.COMPANY_OFFICE_UPDATE,
+    Permission.COMPANY_OFFICE_DELETE,
     Permission.OFFICES_VIEW,
     Permission.OFFICE_VIEW,
     Permission.OFFICE_CREATE,
@@ -27,17 +33,51 @@ const rolesPermissions: Record<Role, Permission[]> = {
   [Role.EDITOR]: [
     Permission.CHAT_VIEW,
     Permission.CHAT_CREATE,
+    Permission.CHAT_DELETE,
     Permission.CHAT_SEND_MESSAGE,
     Permission.USERS_VIEW,
     Permission.USER_VIEW,
+    Permission.USER_INVITE,
     Permission.USER_CREATE,
+    Permission.USER_UPDATE,
+    Permission.USER_DELETE,
+    Permission.USER_RESET_PASSWORD,
+    Permission.COMPANIES_VIEW,
+    Permission.COMPANY_VIEW,
+    Permission.COMPANY_CREATE,
+    Permission.COMPANY_UPDATE,
+    Permission.COMPANY_DELETE,
+    Permission.COMPANY_OFFICES_VIEW,
+    Permission.COMPANY_OFFICE_VIEW,
+    Permission.COMPANY_OFFICE_CREATE,
+    Permission.COMPANY_OFFICE_UPDATE,
+    Permission.COMPANY_OFFICE_DELETE,
+    Permission.OFFICES_VIEW,
+    Permission.OFFICE_VIEW,
+    Permission.OFFICE_CREATE,
+    Permission.OFFICE_UPDATE,
+    Permission.OFFICE_DELETE,
   ],
-  [Role.USER]: [Permission.CHAT_VIEW, Permission.CHAT_CREATE, Permission.CHAT_SEND_MESSAGE],
+  [Role.COMPANY_ADMIN]: [
+    Permission.COMPANY_OFFICES_VIEW,
+    Permission.COMPANY_OFFICE_VIEW,
+    Permission.COMPANY_OFFICE_CREATE,
+    Permission.COMPANY_OFFICE_UPDATE,
+    Permission.COMPANY_OFFICE_DELETE,
+  ],
+  [Role.COMPANY_USER]: [Permission.COMPANY_OFFICES_VIEW, Permission.COMPANY_OFFICE_VIEW],
 };
 
-export const userHasPermissions = (role: Role, requiredPermissions: Permission | Permission[]) => {
-  const rolePermissions = rolesPermissions[role];
+export const currentUserHasPermissions = (requiredPermissions: Permission | Permission[]) => {
+  const role = useSessionStore.getState().data?.role;
+
+  if (!role) {
+    return false;
+  }
+
+  const permissions = rolePermissions[role];
+
   return Array.isArray(requiredPermissions)
-    ? requiredPermissions.every((perm) => rolePermissions.includes(perm))
-    : rolePermissions.includes(requiredPermissions);
+    ? requiredPermissions.every((perm) => permissions.includes(perm))
+    : permissions.includes(requiredPermissions);
 };

--- a/src/services/has-permissions.ts
+++ b/src/services/has-permissions.ts
@@ -1,0 +1,43 @@
+import { Permission, Role } from '@/features/session/types';
+
+const rolesPermissions: Record<Role, Permission[]> = {
+  [Role.ADMIN]: [
+    Permission.CHAT_VIEW,
+    Permission.CHAT_CREATE,
+    Permission.CHAT_DELETE,
+    Permission.CHAT_SEND_MESSAGE,
+    Permission.USERS_VIEW,
+    Permission.USER_VIEW,
+    Permission.USER_INVITE,
+    Permission.USER_CREATE,
+    Permission.USER_UPDATE,
+    Permission.USER_DELETE,
+    Permission.USER_RESET_PASSWORD,
+    Permission.COMPANIES_VIEW,
+    Permission.COMPANY_VIEW,
+    Permission.COMPANY_CREATE,
+    Permission.COMPANY_UPDATE,
+    Permission.COMPANY_DELETE,
+    Permission.OFFICES_VIEW,
+    Permission.OFFICE_VIEW,
+    Permission.OFFICE_CREATE,
+    Permission.OFFICE_UPDATE,
+    Permission.OFFICE_DELETE,
+  ],
+  [Role.EDITOR]: [
+    Permission.CHAT_VIEW,
+    Permission.CHAT_CREATE,
+    Permission.CHAT_SEND_MESSAGE,
+    Permission.USERS_VIEW,
+    Permission.USER_VIEW,
+    Permission.USER_CREATE,
+  ],
+  [Role.USER]: [Permission.CHAT_VIEW, Permission.CHAT_CREATE, Permission.CHAT_SEND_MESSAGE],
+};
+
+export const userHasPermissions = (role: Role, requiredPermissions: Permission | Permission[]) => {
+  const rolePermissions = rolesPermissions[role];
+  return Array.isArray(requiredPermissions)
+    ? requiredPermissions.every((perm) => rolePermissions.includes(perm))
+    : rolePermissions.includes(requiredPermissions);
+};


### PR DESCRIPTION
- Updated Sidebar to include a link to Offices with appropriate icon.
- Enhanced FormatDictionaryValue to handle array of values.
- Modified CompanyPage to improve data validation.
- Refactored CompanyTabs to include tabs for Offices, Users, and Logs.
- Exported useSessionStore for better accessibility.
- Adjusted session types to ensure COMPANY_USER role is defined correctly.
- Added permissions for office management to roles.
- Implemented API functions for office CRUD operations.
- Created columns configuration for displaying office data in tables.
- Developed DeleteOfficeAction component for office deletion.
- Designed OfficesTable component for listing offices with actions.
- Established queries for fetching office data.
- Defined OfficeDTO type for office data structure.
- Created routes for managing offices, including index and detail views.